### PR TITLE
Permit libpq env variable usage

### DIFF
--- a/septentrion/cli.py
+++ b/septentrion/cli.py
@@ -76,26 +76,10 @@ class CommaSeparatedMultipleString(StringParamType):
     is_eager=True,
 )
 @click.option("-v", "--verbose", count=True)
+@click.option("--host", "-H", help="Database host (env: SEPTENTRION_HOST or PGHOST)")
+@click.option("--port", "-p", help="Database port (env: SEPTENTRION_PORT or PGPORT)")
 @click.option(
-    "--host",
-    "-H",
-    help="Database host (env: SEPTENTRION_HOST or PGHOST)",
-    show_default=True,
-    default="localhost",
-)
-@click.option(
-    "--port",
-    "-p",
-    help="Database port (env: SEPTENTRION_PORT or PGPORT)",
-    show_default=True,
-    default=5432,
-)
-@click.option(
-    "--username",
-    "-U",
-    help="Database host (env: SEPTENTRION_USERNAME or PGUSER)",
-    show_default=True,
-    default="postgres",
+    "--username", "-U", help="Database host (env: SEPTENTRION_USERNAME or PGUSER)"
 )
 @click.option(
     "--password/--no-password",
@@ -103,16 +87,10 @@ class CommaSeparatedMultipleString(StringParamType):
     "password_flag",
     help="Prompt for the database password, otherwise read from environment variable "
     "PGPASSWORD, SEPTENTRION_PASSWORD, or ~/.pgpass",
-    show_default=True,
-    default=False,
     envvar=None,
 )
 @click.option(
-    "--dbname",
-    "-d",
-    help="Database name (env: SEPTENTRION_DBNAME or PGDATABASE)",
-    show_default=True,
-    default="postgres",
+    "--dbname", "-d", help="Database name (env: SEPTENTRION_DBNAME or PGDATABASE)"
 )
 @click.option(
     "--table",

--- a/septentrion/db.py
+++ b/septentrion/db.py
@@ -36,7 +36,10 @@ def get_connection():
         if value:
             kwargs[psycopg_name] = value
 
-    connection = psycopg2.connect(**kwargs)
+    # We provide an empty DSN that will be overriden by kwargs in psycopg2
+    # It allows us to give no arguments to connect and libpq will use its
+    # default settings or its own environment variables (PGHOST, PGUSER, ...)
+    connection = psycopg2.connect(dsn="", **kwargs)
 
     # Autocommit=true means we'll have more control over when the code is commited
     # (even if this sounds strange)


### PR DESCRIPTION
libpq uses a lot of environment variables [1] in order to build its
connection parameters.

The usage of these variables was documented but did not work.
Here we remove the default value from Septentrion: if the values are not
defined then psucopg2/libpq will look at its own environment variables.
The default values for psotgresql settings are now the ones from
psycopg2/libpq.

[1] https://www.postgresql.org/docs/10/libpq-envars.html