### PR TITLE
Replace StrictVersion to custom version

### DIFF
--- a/septentrion/db.py
+++ b/septentrion/db.py
@@ -4,14 +4,13 @@ Interact with the migrations table.
 
 import logging
 from contextlib import contextmanager
-from distutils.version import StrictVersion
 from typing import Any, Iterable, Optional, Tuple
 
 import psycopg2
 from psycopg2.extensions import connection as Connection
 from psycopg2.extras import DictCursor
 
-from septentrion import configuration
+from septentrion import configuration, utils
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +117,7 @@ def get_current_schema_version(settings: configuration.Settings) -> Optional[str
     versions = get_applied_versions(settings=settings)
     if not versions:
         return None
-    return str(max(StrictVersion(version) for version in versions))
+    return utils.get_max_version(versions)
 
 
 def get_applied_versions(settings: configuration.Settings) -> Iterable[str]:

--- a/septentrion/exceptions.py
+++ b/septentrion/exceptions.py
@@ -8,3 +8,7 @@ class NoDefaultConfiguration(SeptentrionException):
 
 class NoSeptentrionSection(SeptentrionException):
     pass
+
+
+class InvalidVersion(SeptentrionException):
+    pass

--- a/septentrion/files.py
+++ b/septentrion/files.py
@@ -4,7 +4,6 @@ Interact with the migration files.
 
 import io
 import os
-from distutils.version import StrictVersion
 from typing import Iterable
 
 from septentrion import configuration, utils
@@ -38,9 +37,7 @@ def get_known_versions(settings: configuration.Settings) -> Iterable[str]:
         and utils.is_version(d)
     ]
 
-    # sort versions
-    versions.sort(key=StrictVersion)
-    return versions
+    return utils.sort_versions(versions)
 
 
 def is_manual_migration(migration_path: str) -> bool:

--- a/septentrion/utils.py
+++ b/septentrion/utils.py
@@ -2,8 +2,9 @@
 All functions in here should be easily unit testable
 """
 
-from distutils.version import StrictVersion
 from typing import Iterable, TypeVar
+
+from septentrion import exceptions, versions
 
 
 def sort_versions(iterable: Iterable[str]) -> Iterable[str]:
@@ -13,7 +14,16 @@ def sort_versions(iterable: Iterable[str]) -> Iterable[str]:
     >>> sort_versions(["1.0.1", "2.0", "1.0.3"])
     ["1.0.1", "1.0.3", "2.0"]
     """
-    return sorted(iterable, key=StrictVersion)
+    return sorted(iterable, key=versions.Version)
+
+
+def get_max_version(iterable: Iterable[str]) -> str:
+    """
+    Returns the latest version in the input iterable
+    >>> get_max_version(["1.3", "1.2"])
+    "1.3"
+    """
+    return max(iterable, key=versions.Version)
 
 
 def is_version(vstring: str) -> bool:
@@ -25,8 +35,8 @@ def is_version(vstring: str) -> bool:
     False
     """
     try:
-        StrictVersion(vstring)
-    except ValueError:
+        versions.Version(vstring)
+    except exceptions.InvalidVersion:
         return False
     return True
 

--- a/septentrion/versions.py
+++ b/septentrion/versions.py
@@ -1,0 +1,24 @@
+from septentrion import exceptions
+
+
+class Version:
+    def __init__(self, version_string: str):
+        try:
+            assert version_string
+            self._version = tuple(int(e) for e in version_string.split("."))
+        except (AssertionError, ValueError) as exc:
+            raise exceptions.InvalidVersion(str(exc)) from exc
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, Version):
+            return self._version < other._version
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Version):
+            return self._version == other._version
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        version_string = ".".join(str(n) for n in self._version)
+        return f'{self.__class__.__name__}("{version_string}")'

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ not_skip = __init__.py
 [tool:pytest]
 addopts =
     --cov-report term-missing --cov-branch --cov-report html --cov-report term
-    --cov=septentrion -vv --strict-markers
+    --cov=septentrion -vv
 testpaths =
     tests/unit
     tests/integration

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,36 @@
+import pytest
+
+from septentrion import exceptions, versions
+
+
+def test_version_constructor():
+    version = versions.Version("1.2.3")
+
+    assert version._version == (1, 2, 3)
+
+
+@pytest.mark.parametrize("version", ["", "a.b.2", "1-2", "1."])
+def test_version_bad_string(version):
+    with pytest.raises(exceptions.InvalidVersion):
+        versions.Version(version)
+
+
+def test_version_equal():
+    assert versions.Version("1.2.3") == versions.Version("1.2.03")
+
+
+def test_version_not_equal():
+    assert versions.Version("1.2.3") != versions.Version("1.2.4")
+
+
+def test_version_sort():
+    version_strings = ["2.2.3", "1.2.7", "4.2.4", "2.2.3", "1.2"]
+    version_objs = [versions.Version(s) for s in version_strings]
+    assert str(sorted(version_objs)) == (
+        '[Version("1.2"), Version("1.2.7"), Version("2.2.3"), Version("2.2.3"), '
+        'Version("4.2.4")]'
+    )
+
+
+def test_version_str():
+    assert repr(versions.Version("1.2.3")) == 'Version("1.2.3")'

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    {py36}-{integration,unit}-tests,check-lint
+    py{36}-{integration,unit}-tests,check-lint
 
 [testenv]
 whitelist_externals = make
-usedevelop = True
+usedevelop = true
 extras =
     test
 passenv = PGPASSWORD PGHOST PGUSER PGPORT
@@ -17,7 +17,8 @@ commands =
 extras =
     test
     lint
-ignore_errors=true
+ignore_errors = true
+basepython = python3.6
 commands =
     mypy septentrion
     flake8 .
@@ -30,6 +31,7 @@ extras =
     dev
     # It's important that isort recognizes pytest as a 3rd party
     test
+basepython = python3.6
 commands =
     isort -y
     black .
@@ -37,6 +39,7 @@ commands =
 [testenv:docs]
 extras =
     docs
+basepython = python3.6
 commands =
     sphinx-build -EW docs docs/_build/html {posargs}
     doc8 docs
@@ -48,6 +51,7 @@ extras =
     docs_spelling
 whitelist_externals =
     sort
+basepython = python3.6
 commands =
     sphinx-build -EW -b spelling docs docs/_build/html {posargs}
     # wordlist should be sorted to avoid duplicates


### PR DESCRIPTION
No ticket

This allow to stop using `distutils.StrictVersion` implementation.

### Successful PR Checklist:
- [X] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [X] Had a good time contributing? (feel free to give some feedback)
