### PR TITLE
Make iter_dirs and iter_files yield items in alphabetical order

### DIFF
--- a/septentrion/files.py
+++ b/septentrion/files.py
@@ -9,13 +9,13 @@ from septentrion import configuration, exceptions, utils, versions
 
 
 def iter_dirs(root: pathlib.Path) -> Iterable[pathlib.Path]:
-    return (d for d in root.iterdir() if d.is_dir())
+    return (d for d in sorted(root.iterdir()) if d.is_dir())
 
 
 def iter_files(
     root: pathlib.Path, ignore_symlinks: bool = False
 ) -> Iterable[pathlib.Path]:
-    for f in root.iterdir():
+    for f in sorted(root.iterdir()):
         if not f.is_file():
             continue
         if ignore_symlinks and f.is_symlink():


### PR DESCRIPTION
This PR makes the `iter_dirs` and `iter_files` functions yield their items in alphabetical order.

The `tests/integration/test_files.py::test_iter_files` test didn't pass for me because of that.

### Successful PR Checklist:
- [X] Tests  **Not relevant**
- [X] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation)) **Not relevant**
- [X] Had a good time contributing? (feel free to give some feedback) **First contribs always feel good** :smile: 
