### PR TITLE
PY-32 Extend septentrion lib module

### DIFF
--- a/septentrion/__init__.py
+++ b/septentrion/__init__.py
@@ -1,7 +1,19 @@
 from septentrion import metadata as _metadata_module
-from septentrion.lib import fake, migrate, show_migrations
+from septentrion.lib import (
+    build_migration_plan,
+    fake,
+    is_schema_initialized,
+    migrate,
+    show_migrations,
+)
 
-__all__ = ["fake", "migrate", "show_migrations"]
+__all__ = [
+    "build_migration_plan",
+    "fake",
+    "is_schema_initialized",
+    "migrate",
+    "show_migrations",
+]
 
 _metadata = _metadata_module.extract_metadata("septentrion")
 __author__ = _metadata["author"]

--- a/septentrion/lib.py
+++ b/septentrion/lib.py
@@ -1,6 +1,6 @@
 import logging
 
-from septentrion import core, exceptions, migration, style, versions
+from septentrion import core, db, exceptions, migration, style, versions
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,16 @@ def migrate(*, migration_applied_callback=None, **settings_kwargs):
     migration.migrate(
         migration_applied_callback=migration_applied_callback, **lib_kwargs,
     )
+
+
+def is_schema_initialized(**settings_kwargs):
+    lib_kwargs = initialize(settings_kwargs)
+    return db.is_schema_initialized(settings=lib_kwargs["settings"])
+
+
+def build_migration_plan(**settings_kwargs):
+    lib_kwargs = initialize(settings_kwargs)
+    return core.build_migration_plan(settings=lib_kwargs["settings"])
 
 
 def fake(version: str, **settings_kwargs):

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -49,3 +49,19 @@ def test_show_migrations(fake_db, mocker):
     lib.show_migrations()
 
     mock.assert_called_with(settings=mocker.ANY, stylist=mocker.ANY)
+
+
+def test_is_schema_initialized(fake_db, mocker):
+    mock = mocker.patch("septentrion.db.is_schema_initialized", return_value="is it ?")
+
+    assert lib.is_schema_initialized() == "is it ?"
+
+    mock.assert_called_with(settings=mocker.ANY)
+
+
+def test_build_migration_plan(fake_db, mocker):
+    mock = mocker.patch("septentrion.core.build_migration_plan", return_value="is it ?")
+
+    assert lib.build_migration_plan() == "is it ?"
+
+    mock.assert_called_with(settings=mocker.ANY)


### PR DESCRIPTION
Add access to is_schema_initialized and build_migration_plan functions

I'm working on using septentrion in https://github.com/peopledoc/django-north
and I realized it needs those 2 features to check for unapplied migrations or uniitialized schema in its `runserver` command.

Cf. #60  and PY-32

### Successful PR Checklist:
- [x] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [ ] Had a good time contributing? (feel free to give some feedback)
