### PR TITLE
Fix loading of configuration when no file is available (#59)

### DIFF
--- a/septentrion/cli.py
+++ b/septentrion/cli.py
@@ -34,27 +34,7 @@ click.option = functools.partial(click.option, show_default=True)  # type: ignor
 
 
 def load_config(ctx: click.Context, param: click.Parameter, value: TextIO) -> None:
-    if not value:
-        try:
-            file_contents, file = configuration.read_default_configuration_files()
-        except exceptions.NoDefaultConfiguration:
-            pass
-    else:
-        file = getattr(value, "name", "stdin")
-        logger.info(f"Reading configuration from {file}")
-        file_contents = value.read()
-
-    try:
-        default = configuration.parse_configuration_file(file_contents)
-    except exceptions.NoSeptentrionSection:
-        if file in configuration.DEDICATED_CONFIGURATION_FILES:
-            click.echo(
-                f"Configuration file found at {file} but contains no septentrion "
-                "section"
-            )
-        default = {}
-
-    ctx.default_map = default
+    ctx.default_map = configuration.load_configuration_files(value)
 
 
 CONTEXT_SETTINGS = {

--- a/septentrion/cli.py
+++ b/septentrion/cli.py
@@ -76,7 +76,7 @@ class CommaSeparatedMultipleString(StringParamType):
     is_eager=True,
     callback=load_config,
     help="Config file to use (env: SEPTENTRION_CONFIG_FILE)  "
-    f"[default: {' or '.join(configuration.ALL_CONFIGURATION_FILES)}]",
+    f"[default: {' or '.join(str(p) for p in configuration.ALL_CONFIGURATION_FILES)}]",
     type=click.File("rb"),
 )
 @click.version_option(__version__, "-V", "--version", prog_name="septentrion")

--- a/septentrion/configuration.py
+++ b/septentrion/configuration.py
@@ -5,7 +5,7 @@ the settings, see cli.py (for now)
 import configparser
 import logging
 import pathlib
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, TextIO, Tuple, Union
 
 from septentrion import exceptions
 
@@ -142,3 +142,30 @@ class Settings:
     def update(self, values: Dict) -> None:
         for key, value in values.items():
             self.set(key, value)
+
+
+def load_configuration_files(value: TextIO) -> Dict[str, Any]:
+    """
+    Load configuration from default source files.
+    """
+    if not value:
+        try:
+            file_contents, file = read_default_configuration_files()
+        except exceptions.NoDefaultConfiguration:
+            return {}
+    else:
+        file = getattr(value, "name", "stdin")
+        logger.info(f"Reading configuration from {file}")
+        file_contents = value.read()
+
+    try:
+        return parse_configuration_file(file_contents)
+    except exceptions.NoSeptentrionSection:
+        if file in DEDICATED_CONFIGURATION_FILES:
+            logger.warning(
+                f"Configuration file found at {file} but contains no "
+                "septentrion section"
+            )
+
+    # No configuration found in files ; use stock default values
+    return {}

--- a/septentrion/configuration.py
+++ b/septentrion/configuration.py
@@ -5,21 +5,27 @@ the settings, see cli.py (for now)
 import configparser
 import logging
 import pathlib
-from typing import Any, Dict, TextIO, Tuple, Union
+from typing import Any, Dict, Optional, TextIO, Tuple, Union
 
 from septentrion import exceptions
 
 logger = logging.getLogger(__name__)
 
 # These are the configuration files only used by septentrion
-DEDICATED_CONFIGURATION_FILES = [
-    "./septentrion.ini",
-    "~/.config/septentrion.ini",
-    "/etc/septentrion.ini",
+DEDICATED_CONFIGURATION_FILENAME = "septentrion.ini"
+CONFIGURATION_PATHS = [
+    pathlib.Path("./"),
+    pathlib.Path("~/.config/"),
+    pathlib.Path("/etc/"),
 ]
+DEDICATED_CONFIGURATION_FILES = [
+    folder.expanduser().resolve() / DEDICATED_CONFIGURATION_FILENAME
+    for folder in CONFIGURATION_PATHS
+]
+print(DEDICATED_CONFIGURATION_FILES)
 # These are the files that can contain septentrion configuration, but
 # it's also ok if they exist and they don't configure septentrion.
-COMMON_CONFIGURATION_FILES = ["./setup.cfg"]
+COMMON_CONFIGURATION_FILES = [pathlib.Path("./setup.cfg")]
 
 ALL_CONFIGURATION_FILES = DEDICATED_CONFIGURATION_FILES + COMMON_CONFIGURATION_FILES
 
@@ -44,7 +50,7 @@ DEFAULTS = {
 }
 
 
-def read_default_configuration_files() -> Tuple[str, str]:
+def read_default_configuration_files() -> Tuple[str, pathlib.Path]:
     for file in ALL_CONFIGURATION_FILES:
         try:
             return read_configuration_file(file), file
@@ -56,7 +62,7 @@ def read_default_configuration_files() -> Tuple[str, str]:
     raise exceptions.NoDefaultConfiguration
 
 
-def read_configuration_file(path: str) -> str:
+def read_configuration_file(path: pathlib.Path) -> str:
     with open(path, "r") as handler:
         logger.info(f"Reading configuration from {path}")
         return handler.read()
@@ -144,26 +150,35 @@ class Settings:
             self.set(key, value)
 
 
-def load_configuration_files(value: TextIO) -> Dict[str, Any]:
+def load_configuration_files(value: Optional[TextIO]) -> Dict[str, Any]:
     """
     Load configuration from default source files.
     """
+    expected_section = True
+    file: Union[pathlib.Path, str]
+
     if not value:
         try:
             file_contents, file = read_default_configuration_files()
         except exceptions.NoDefaultConfiguration:
             return {}
+        if file not in DEDICATED_CONFIGURATION_FILES:
+            expected_section = False
     else:
-        file = getattr(value, "name", "stdin")
+        if hasattr(value, "name"):
+            file = pathlib.Path(value.name)
+        else:
+            file = "stdin"
         logger.info(f"Reading configuration from {file}")
+
         file_contents = value.read()
 
     try:
         return parse_configuration_file(file_contents)
     except exceptions.NoSeptentrionSection:
-        if file in DEDICATED_CONFIGURATION_FILES:
+        if expected_section:
             logger.warning(
-                f"Configuration file found at {file} but contains no "
+                f"Configuration file found at {str(file)} but contains no "
                 "septentrion section"
             )
 

--- a/tests/acceptance/test_cli.py
+++ b/tests/acceptance/test_cli.py
@@ -8,8 +8,18 @@ def test_version(cli_runner):
     )
 
 
-def test_current_database_state(cli_runner, db):
+def test_no_configuration_file(cli_runner, temporary_directory, mocker):
+    mocker.patch("septentrion.core.describe_migration_plan")
+    mocker.patch("septentrion.db.create_table")
+    result = cli_runner.invoke(
+        __main__.main,
+        ["--target-version=0.0.0", "show-migrations"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, (result.output,)
 
+
+def test_current_database_state(cli_runner, db):
     result = cli_runner.invoke(
         __main__.main,
         [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,9 @@ def fake_db(mocker):
     patch = mocker.patch("septentrion.db.execute")
     patch.return_value.__enter__ = fake_execute
     yield fake_execute
+
+
+@pytest.fixture()
+def temporary_directory(tmpdir):
+    with tmpdir.as_cwd():
+        yield


### PR DESCRIPTION
Closes #59 

- Fix loading of configuration when no file is available
- refactor load_config: click integration on one side, septentrion logic on the other side. This lets us unit test the logic much more easily.
- Default path is now internally a list of pathlib.Path, instead of str. Thanks to this, we can show full paths in logs, which should make things easier

### Successful PR Checklist:
- [x] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (feel free to give some feedback) < Thanks @brunobord, it's been a blast !
