### PR TITLE
Explicitly import psycopg2.errors for old psycopg2 versions

### DIFF
--- a/septentrion/db.py
+++ b/septentrion/db.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Optional, Tuple
 
 import psycopg2
 import psycopg2.sql
+import psycopg2.errors
 from psycopg2.extensions import connection as Connection
 from psycopg2.extras import DictCursor
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,4 +1,5 @@
 import psycopg2
+import psycopg2.errors
 import pytest
 
 from septentrion import configuration, db


### PR DESCRIPTION
Cf. no ticket

I haven't tested explicitely to find when the behaviour changed, but with `psycopg2==2.7.7`, explicit import of `psycopg2.errors` is required

### Successful PR Checklist:
- [ ] Tests < Apart from testing with old versions of psycopg2, I'm not sure how to test for that.
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (feel free to give some feedback)
