### PR TITLE
psycopg2 is required at 2.8.0 minimum

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -47,7 +47,7 @@ Within a virtualenv_, install Septentrion with:
 
 .. code-block:: console
 
-    (venv) $ pip install septentrion
+    (venv) $ pip install septentrion[psycopg2_binary]
 
 Next we will configure the connection to the PostgreSQL database. We can do this either with command line flags,
 environment variables or a configuration file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e .[dev,test,lint,docs]
+-e .[dev,test,lint,docs,psycopg2_binary]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ zip_safe = True
 include_package_data = True
 packages = find:
 install_requires =
-    psycopg2_binary
     Click
     sqlparse
     colorama
@@ -74,6 +73,12 @@ docs =
 
 docs_spelling =
     sphinxcontrib-spelling
+
+psycopg2_binary =
+    psycopg2_binary>=2.8.0
+
+psycopg2 =
+    psycopg2>=2.8.0
 
 [flake8]
 max-line-length = 88

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,5 +39,5 @@ Everything that's not unit tested should be integation tested, so we may aim for
 `pytest` and `coverage`. Install with:
 
 ```console
-$ pip install -e ".[test]"
+$ pip install -e ".[test,psycopg2_binary]"
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ whitelist_externals = make
 usedevelop = true
 extras =
     test
+    psycopg2_binary
 passenv = PGPASSWORD PGHOST PGUSER PGPORT
 commands =
     pip freeze -l
@@ -18,6 +19,7 @@ commands =
 extras =
     test
     lint
+    psycopg2_binary
 ignore_errors = true
 basepython = python3.6
 commands =
@@ -32,6 +34,7 @@ extras =
     dev
     # It's important that isort recognizes pytest as a 3rd party
     test
+    psycopg2_binary
 basepython = python3.6
 commands =
     isort -y
@@ -40,6 +43,7 @@ commands =
 [testenv:docs]
 extras =
     docs
+    psycopg2_binary
 basepython = python3.6
 commands =
     sphinx-build -EW docs docs/_build/html {posargs}
@@ -50,6 +54,7 @@ extras =
     async
     docs
     docs_spelling
+    psycopg2_binary
 whitelist_externals =
     sort
 basepython = python3.6


### PR DESCRIPTION
Cf. no ticket

It's actually problematic that septentrion depends on psycopg2 OR psycopg2-binary, because this means downstream projects can't choose anymore whether they want to use one or the other. We should be removing the dependency altogether and document the need to independently install *a* psycopg2 over 2.8.0, but this fills me with sadness.

Any suggestion ?

Edit: added 2 extras. And a lot of sorrow. At least, now it's solved; you decide whether you want `septentrion[psycopg2]` or `septentrion[psycopg2-binary]`

### Successful PR Checklist:
- [ ] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [ ] Had a good time contributing? (feel free to give some feedback) < Not. Not a single bit.
