### PR TITLE
Pass psql configuration by environment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,18 @@
 import psycopg2
 import pytest
+import os
 
 from septentrion import configuration
+
+
+def db_params_from_env():
+    return {
+        "user": os.environ.get("PGUSER"),
+        "dbname": os.environ.get("PGDATABASE"),
+        "host": os.environ.get("PGHOST"),
+        "port": os.environ.get("PGPORT"),
+        "password": os.environ.get("PGPASSWORD"),
+    }
 
 
 @pytest.fixture
@@ -18,7 +29,7 @@ def db():
     cursor.execute(f"DROP DATABASE IF EXISTS {test_db_name}")
     cursor.execute(f"CREATE DATABASE {test_db_name}")
 
-    params = connection.get_dsn_parameters()
+    params = db_params_from_env()
     params["dbname"] = test_db_name
     yield params
 


### PR DESCRIPTION
Cf. no ticket

Septentrion is currently broken: password can only be passed via PGPASSWORD, the septentrion password option is not considered (because `--password {password}` is not a valid CLI flag)

(ping @k4nar)

### Successful PR Checklist:
- [x] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (feel free to give some feedback)
