### PR TITLE
Fix versions

### DIFF
--- a/septentrion/configuration.py
+++ b/septentrion/configuration.py
@@ -7,7 +7,7 @@ import logging
 import pathlib
 from typing import Any, Dict, Optional, TextIO, Tuple, Union
 
-from septentrion import exceptions
+from septentrion import exceptions, versions
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +145,18 @@ class Settings:
         if isinstance(migrations_root, str):
             migrations_root = pathlib.Path(migrations_root)
         return migrations_root
+
+    def clean_schema_version(self, version: Union[str, versions.Version]):
+        if isinstance(version, str):
+            version = versions.Version.from_string(version)
+
+        return version
+
+    def clean_target_version(self, version: Union[str, versions.Version]):
+        if isinstance(version, str):
+            version = versions.Version.from_string(version)
+
+        return version
 
     def __repr__(self):
         return repr(self._settings)

--- a/septentrion/core.py
+++ b/septentrion/core.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 def initialize(**kwargs):
     settings = configuration.Settings(**kwargs)
 
-    # All other commands will need the table to be created
-    logger.info("Ensuring migration table exists")
     if settings.CREATE_TABLE:
+        # All other commands will need the table to be created
+        logger.info("Ensuring migration table exists")
         db.create_table(settings=settings)  # idempotent
 
     return settings

--- a/septentrion/db.py
+++ b/septentrion/db.py
@@ -2,6 +2,7 @@
 Interact with the migrations table.
 """
 
+import datetime
 import logging
 from contextlib import contextmanager
 from typing import Any, Iterable, Optional, Tuple
@@ -111,8 +112,8 @@ CREATE TABLE IF NOT EXISTS {table} (
 query_max_version = """SELECT DISTINCT {version_column} FROM {table} """
 
 query_write_migration = """
-    INSERT INTO {table} ({version_column}, {name_column})
-    VALUES (%s, %s)
+    INSERT INTO {table} ({version_column}, {name_column}, {applied_at_column})
+    VALUES (%s, %s, %s)
 """
 
 query_get_applied_migrations = """
@@ -174,6 +175,6 @@ def write_migration(
     Query(
         settings=settings,
         query=query_write_migration,
-        args=(version.original_string, name),
+        args=(version.original_string, name, datetime.datetime.utcnow()),
         commit=True,
     )()

--- a/septentrion/lib.py
+++ b/septentrion/lib.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Iterable
 
-from septentrion import core, db, exceptions, files, migration, style, versions
+from septentrion import core, db, files, migration, style, versions
 
 logger = logging.getLogger(__name__)
 
@@ -9,14 +9,6 @@ logger = logging.getLogger(__name__)
 def initialize(settings_kwargs):
     quiet = settings_kwargs.pop("quiet", False)
     stylist = style.noop_stylist if quiet else style.stylist
-
-    if "target_version" in settings_kwargs:
-        try:
-            value = settings_kwargs["target_version"]
-            version = versions.Version.from_string(value)
-            settings_kwargs["target_version"] = version
-        except exceptions.InvalidVersion:
-            raise ValueError(f"{value} is not a valid version")
 
     settings = core.initialize(**settings_kwargs)
     return {"settings": settings, "stylist": stylist}

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -1,7 +1,10 @@
+import datetime
+
 import psycopg2.errors
 import pytest
 
 from septentrion import db as db_module
+from septentrion import versions
 
 
 def test_execute(db, settings_factory):
@@ -19,3 +22,25 @@ def test_execute_sql_injection(db, settings_factory):
             assert cursor.fetchall() == [[1]]
 
     assert 'relation ""pg_enum"; -- SQLi" does not exist' in str(exc_info.value)
+
+
+def test_write_migration(db, settings_factory):
+    settings = settings_factory(**db)
+    db_module.create_table(settings=settings)
+
+    db_module.write_migration(
+        settings=settings,
+        version=versions.Version.from_string("1.2.3"),
+        name="some_migration.sql",
+    )
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    with db_module.Query(settings=settings, query="SELECT * FROM {table}",) as cur:
+        id, version, name, date = list(cur)[0]
+
+    assert id == 1
+    assert version == "1.2.3"
+    assert name == "some_migration.sql"
+    one_sec = datetime.timedelta(seconds=1)
+    assert now - one_sec < date < now + one_sec

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 import pytest
 
-from septentrion import configuration, exceptions
+from septentrion import configuration, exceptions, versions
 
 
 def test_get_config_settings():
@@ -118,3 +118,15 @@ def test_load_configuration_files_default_files(
             for r in warnings
         ]
     )
+
+
+def test_settings_clean_target_version():
+    target = configuration.Settings(target_version="1.2.3").TARGET_VERSION
+
+    assert target == versions.Version(version_tuple=(1, 2, 3), original_string="1.2.3")
+
+
+def test_settings_clean_schema_version():
+    schema = configuration.Settings(schema_version="1.2.3").SCHEMA_VERSION
+
+    assert schema == versions.Version(version_tuple=(1, 2, 3), original_string="1.2.3")


### PR DESCRIPTION
Cf. no ticket

- Lib: make target_version and schema_version Version objects

Before this change, schema_version was taken as a string, and comparison with Version objects failed.

- Write date in applied_at column

This is not the nicest thing because there should be a default here, but django-north will need to seriously step up its game before septentrion can rely on the DB default, sadly.

### Successful PR Checklist:
- [x] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (feel free to give some feedback)
