### PR TITLE
Disregard migrations older than the schema

### DIFF
--- a/septentrion/migration.py
+++ b/septentrion/migration.py
@@ -25,17 +25,21 @@ def migrate(
 ) -> None:
 
     logger.info("Starting migrations")
+
+    schema_version = core.get_best_schema_version(settings=settings)
+
     if not db.is_schema_initialized(settings=settings):
         logger.info("Migration table is empty, loading a schema")
         # schema not inited
-        schema_version = core.get_best_schema_version(settings=settings)
         init_schema(settings=settings, init_version=schema_version, stylist=stylist)
 
     # play migrations
     with stylist.activate("title") as echo:
         echo("Applying migrations")
 
-    for plan in core.build_migration_plan(settings=settings):
+    for plan in core.build_migration_plan(
+        settings=settings, schema_version=schema_version
+    ):
         version = plan["version"]
         logger.info("Processing version %s", version)
         with stylist.activate("subtitle") as echo:

--- a/septentrion/utils.py
+++ b/septentrion/utils.py
@@ -2,6 +2,7 @@
 All functions in here should be easily unit testable
 """
 
+import itertools
 from typing import Iterable, TypeVar
 
 from septentrion import exceptions, versions
@@ -37,3 +38,15 @@ def until(iterable: Iterable[T], value: T) -> Iterable[T]:
             break
     else:
         raise ValueError("{} not found".format(value))
+
+
+def since(iterable: Iterable[T], value: T) -> Iterable[T]:
+    """
+    Returns the values from iterable starting after the element is found
+    >>> list(until(range(300), 297))
+    [298, 299]
+    """
+    it = itertools.dropwhile((lambda x: x != value), iterable)
+    # Drop the first element
+    next(it)
+    yield from it


### PR DESCRIPTION
Cf. #32 

With this PR, migrations older than the schema are not considered. If no schema is explicitely configured (even if one is used, because the latest schema is automatically used), then all migrations are considered.

Is it the right thing to do, or should I disregard all migrations older than the schema event when schema is not explicitely provided ?

Missing tests (& doc but the Septentrion doc is... Not ready)

### Successful PR Checklist:
- [ ] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (feel free to give some feedback)
