### PR TITLE
Lib: fix build_migration_plan

### DIFF
--- a/septentrion/lib.py
+++ b/septentrion/lib.py
@@ -31,7 +31,10 @@ def is_schema_initialized(**settings_kwargs):
 
 def build_migration_plan(**settings_kwargs):
     lib_kwargs = initialize(settings_kwargs)
-    return core.build_migration_plan(settings=lib_kwargs["settings"])
+    schema_version = core.get_best_schema_version(settings=lib_kwargs["settings"])
+    return core.build_migration_plan(
+        settings=lib_kwargs["settings"], schema_version=schema_version
+    )
 
 
 def fake(version: str, **settings_kwargs):

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -57,11 +57,16 @@ def test_is_schema_initialized(fake_db, mocker):
 
 
 def test_build_migration_plan(fake_db, mocker):
-    mock = mocker.patch("septentrion.core.build_migration_plan", return_value="is it ?")
+    build_migration_plan = mocker.patch(
+        "septentrion.core.build_migration_plan", return_value="is it ?"
+    )
+    get_best_schema_version = mocker.patch("septentrion.core.get_best_schema_version")
 
     assert lib.build_migration_plan() == "is it ?"
 
-    mock.assert_called_with(settings=mocker.ANY)
+    build_migration_plan.assert_called_with(
+        settings=mocker.ANY, schema_version=get_best_schema_version.return_value
+    )
 
 
 def test_load_fixtures(fake_db, mocker):


### PR DESCRIPTION
No ticket

We recently changed the signature of build_migration_plan and we missed a spot.

We're on a schedule, so I'm fixing the existing thest, but I'm not ensuring that next time we have the problem, the tests will fail. I'm leaving this for a subsequent PR.

### Successful PR Checklist:
- [x] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (feel free to give some feedback)
