### PR TITLE
Ensure env-vars are handled as strings

### DIFF
--- a/septentrion/runner.py
+++ b/septentrion/runner.py
@@ -38,7 +38,7 @@ class Script:
             "PGUSER": self.settings.USERNAME,
             "PGPASSWORD": self.settings.PASSWORD,
         }
-        return {key: value for key, value in environment.items() if value}
+        return {key: str(value) for key, value in environment.items() if value}
 
     def _run_simple(self):
 

--- a/tests/integration/test_runner.py
+++ b/tests/integration/test_runner.py
@@ -58,6 +58,18 @@ def test_run_psql_not_found(run_script, env):
     )
 
 
+def test_run_integer_in_settings(db, settings_factory, env, tmp_path):
+    settings = settings_factory(**db)
+    # settings are noew stringified to prevent subprocess.run
+    # crashing while building the appropriate command line.
+    settings.PORT = 5432
+    path = tmp_path / "script.sql"
+    path.write_text("SELECT 1;")
+    with io.open(path, "r", encoding="utf8") as f:
+        script = Script(settings, f, path)
+        script.run()
+
+
 def test_run_with_meta_loop(db, settings_factory, run_script):
     settings = settings_factory(**db)
 

--- a/tests/integration/test_runner.py
+++ b/tests/integration/test_runner.py
@@ -60,7 +60,7 @@ def test_run_psql_not_found(run_script, env):
 
 def test_run_integer_in_settings(db, settings_factory, env, tmp_path):
     settings = settings_factory(**db)
-    # settings are noew stringified to prevent subprocess.run
+    # settings are stringified to prevent subprocess.run
     # crashing while building the appropriate command line.
     settings.PORT = 5432
     path = tmp_path / "script.sql"


### PR DESCRIPTION
This avoids suprocess.run to fail ambiguously due to non-string values inherited from configuration
(like postgresql' port number). 

Cf. #83.

### Successful PR Checklist:
- [X] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/septentrion/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [X] Had a good time contributing? (feel free to give some feedback)
