### PR TITLE
#90 fix CLI call with --config-file option

### DIFF
--- a/septentrion/cli.py
+++ b/septentrion/cli.py
@@ -77,7 +77,7 @@ class CommaSeparatedMultipleString(StringParamType):
     callback=load_config,
     help="Config file to use (env: SEPTENTRION_CONFIG_FILE)  "
     f"[default: {' or '.join(str(p) for p in configuration.ALL_CONFIGURATION_FILES)}]",
-    type=click.File("rb"),
+    type=click.File("r"),
 )
 @click.version_option(__version__, "-V", "--version", prog_name="septentrion")
 @click.option(

--- a/tests/acceptance/test_cli.py
+++ b/tests/acceptance/test_cli.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from septentrion import __main__, configuration
 from septentrion import db as db_module
 
@@ -59,3 +61,15 @@ def test_current_database_state(cli_runner, db):
     assert "Version 1.1" in result.output
     assert "Applying 1.1-index-ddl.sql ..." in result.output
     assert "Applied 1.1-index-ddl.sql" in result.output
+
+
+def test_configuration_file_from_cli(cli_runner, temporary_directory, mocker):
+    mocker.patch("septentrion.core.describe_migration_plan")
+    mocker.patch("septentrion.db.create_table")
+    path = pathlib.Path(__file__).parents[2] / "tests/test_data/config_file.ini"
+    result = cli_runner.invoke(
+        __main__.main,
+        [f"--config-file={path}", "show-migrations"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, (result.output,)

--- a/tests/test_data/config_file.ini
+++ b/tests/test_data/config_file.ini
@@ -1,0 +1,9 @@
+[septentrion]
+schema_version=20.10
+target_version=20.11
+schema_template=schema_{}.sql
+before_schema_file=
+    roles.sql
+after_schema_file=
+    after_schemas.sql
+fixtures_template=fixtures_{}.sql

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -90,6 +90,13 @@ def test_load_configuration_files_value(caplog, conf, expected, has_warning):
     )
 
 
+def test_load_configuration_files_value_from_file(caplog, mocker):
+    with open(
+        pathlib.Path(__file__).parents[2] / "tests/test_data/config_file.ini", "r"
+    ) as f:
+        configuration.load_configuration_files(value=f)
+
+
 @pytest.mark.parametrize(
     "conf, filename, expected, has_warning",
     [


### PR DESCRIPTION
Cf. #90 

New test without the fix:
```
$ pytest tests/acceptance/test_cli.py::test_configuration_file_from_cli
...
/home/tbcvl/Documents/dev/septentrion/septentrion/cli.py:37: in load_config
    ctx.default_map = configuration.load_configuration_files(value)
/home/tbcvl/Documents/dev/septentrion/septentrion/configuration.py:195: in load_configuration_files
    return parse_configuration_file(file_contents)
/home/tbcvl/Documents/dev/septentrion/septentrion/configuration.py:84: in parse_configuration_file
    parser.read_string(content)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <configparser.ConfigParser object at 0x7f14b5fa3438>
string = b'[septentrion]\nschema_version=20.10\ntarget_version=20.11\nschema_template=schema_{}.sql\nbefore_schema_file=\n    roles.sql\nafter_schema_file=\n    after_schemas.sql\nfixtures_template=fixtures_{}.sql\n', source = '<string>'

    def read_string(self, string, source='<string>'):
        """Read configuration from a given string."""
>       sfile = io.StringIO(string)
E       TypeError: initial_value must be str or None, not bytes

/usr/local/lib/python3.6/configparser.py:722: TypeError
```

I'm not familiar with septentrion architecture, feel free to tell me if there's a better place for the fix.

### Successful PR Checklist:
- [x] Tests
- [x] bugfix, no documentation needed
