### PR TITLE
Fix build_migration_plan which ommitted the first version

### DIFF
--- a/septentrion/utils.py
+++ b/septentrion/utils.py
@@ -44,9 +44,6 @@ def since(iterable: Iterable[T], value: T) -> Iterable[T]:
     """
     Returns the values from iterable starting after the element is found
     >>> list(until(range(300), 297))
-    [298, 299]
+    [297, 298, 299]
     """
-    it = itertools.dropwhile((lambda x: x != value), iterable)
-    # Drop the first element
-    next(it)
-    yield from it
+    yield from itertools.dropwhile((lambda x: x != value), iterable)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -2,13 +2,13 @@ import pathlib
 
 import pytest
 
-from septentrion import configuration, core, exceptions, versions
+from septentrion import configuration, core, exceptions
 from septentrion.versions import Version
 
 
 @pytest.fixture
 def known_versions(mocker):
-    versions_ = [versions.Version.from_string(v) for v in ("0", "1.1", "1.2", "1.3")]
+    versions_ = [Version.from_string(v) for v in ("0", "1.1", "1.2", "1.3")]
     mocker.patch("septentrion.core.files.get_known_versions", return_value=versions_)
 
     return versions_
@@ -18,26 +18,24 @@ def test_get_applied_versions(mocker, known_versions):
     mocker.patch(
         "septentrion.core.db.get_applied_versions",
         return_value=[
-            versions.Version.from_string("1.0"),
-            versions.Version.from_string("1.1"),
+            Version.from_string("1.0"),
+            Version.from_string("1.1"),
         ],
     )
     settings = configuration.Settings()
     versions_ = core.get_applied_versions(settings=settings)
 
-    assert versions_ == [versions.Version.from_string("1.1")]
+    assert versions_ == [Version.from_string("1.1")]
 
 
 def test_get_closest_version_unknown_target_version(known_versions):
-    settings = configuration.Settings(
-        target_version=versions.Version.from_string("1.5")
-    )
+    settings = configuration.Settings(target_version=Version.from_string("1.5"))
 
     # target_version is not a known version
     with pytest.raises(ValueError):
         core.get_closest_version(
             settings=settings,
-            target_version=versions.Version.from_string("1.5"),
+            target_version=Version.from_string("1.5"),
             sql_tpl="schema_{}.sql",
             existing_files=[],
         )
@@ -48,12 +46,12 @@ def test_get_closest_version_ok(known_versions):
 
     version = core.get_closest_version(
         settings=settings,
-        target_version=versions.Version.from_string("1.1"),
+        target_version=Version.from_string("1.1"),
         sql_tpl="schema_{}.sql",
         existing_files=["schema_1.0.sql", "schema_1.1.sql"],
     )
 
-    assert version == versions.Version.from_string("1.1")
+    assert version == Version.from_string("1.1")
 
 
 def test_get_closest_version_schema_doesnt_exist(known_versions):
@@ -61,7 +59,7 @@ def test_get_closest_version_schema_doesnt_exist(known_versions):
 
     version = core.get_closest_version(
         settings=settings,
-        target_version=versions.Version.from_string("1.1"),
+        target_version=Version.from_string("1.1"),
         sql_tpl="schema_{}.sql",
         existing_files=["schema_1.0.sql", "schema_1.2.sql"],
     )
@@ -75,10 +73,10 @@ def test_get_closest_version_earlier_schema(known_versions):
 
     version = core.get_closest_version(
         settings=settings,
-        target_version=versions.Version.from_string("1.3"),
+        target_version=Version.from_string("1.3"),
         sql_tpl="schema_{}.sql",
         existing_files=["schema_1.0.sql", "schema_1.1.sql"],
-        force_version=versions.Version.from_string("1.2"),
+        force_version=Version.from_string("1.2"),
     )
 
     assert version is None
@@ -93,10 +91,10 @@ def test_get_closest_version_schema_force_ko(known_versions):
     with pytest.raises(ValueError):
         core.get_closest_version(
             settings=settings,
-            target_version=versions.Version.from_string("1.1"),
+            target_version=Version.from_string("1.1"),
             sql_tpl="schema_{}.sql",
             existing_files=["schema_1.0.sql", "schema_1.1.sql"],
-            force_version=versions.Version.from_string("1.4"),
+            force_version=Version.from_string("1.4"),
         )
 
 
@@ -105,13 +103,13 @@ def test_get_closest_version_schema_force_ok(known_versions):
 
     version = core.get_closest_version(
         settings=settings,
-        target_version=versions.Version.from_string("1.3"),
+        target_version=Version.from_string("1.3"),
         sql_tpl="schema_{}.sql",
         existing_files=["schema_1.2.sql", "schema_1.3.sql"],
-        force_version=versions.Version.from_string("1.2"),
+        force_version=Version.from_string("1.2"),
     )
 
-    assert version == versions.Version.from_string("1.2")
+    assert version == Version.from_string("1.2")
 
 
 def test_get_closest_version_schema_force_dont_exist(known_versions):
@@ -119,10 +117,10 @@ def test_get_closest_version_schema_force_dont_exist(known_versions):
 
     version = core.get_closest_version(
         settings=settings,
-        target_version=versions.Version.from_string("1.3"),
+        target_version=Version.from_string("1.3"),
         sql_tpl="schema_{}.sql",
         existing_files=["schema_1.1.sql", "schema_1.3.sql"],
-        force_version=versions.Version.from_string("1.2"),
+        force_version=Version.from_string("1.2"),
     )
 
     # schema_1.2.sql doesn't exist
@@ -134,13 +132,11 @@ def test_get_best_schema_version_ok(mocker, known_versions):
         "septentrion.core.files.get_special_files",
         return_value=["schema_1.1.sql", "schema_1.2.sql"],
     )
-    settings = configuration.Settings(
-        target_version=versions.Version.from_string("1.2")
-    )
+    settings = configuration.Settings(target_version=Version.from_string("1.2"))
 
     version = core.get_best_schema_version(settings=settings)
 
-    assert version == versions.Version.from_string("1.2")
+    assert version == Version.from_string("1.2")
 
 
 def test_get_best_schema_version_ko(mocker, known_versions):
@@ -148,19 +144,15 @@ def test_get_best_schema_version_ko(mocker, known_versions):
         "septentrion.core.files.get_special_files",
         return_value=["schema_1.0.sql", "schema_1.3.sql"],
     )
-    settings = configuration.Settings(
-        target_version=versions.Version.from_string("1.2")
-    )
+    settings = configuration.Settings(target_version=Version.from_string("1.2"))
 
     with pytest.raises(exceptions.SeptentrionException):
         core.get_best_schema_version(settings=settings)
 
 
 def test_build_migration_plan_unknown_version(known_versions):
-    settings = configuration.Settings(
-        target_version=versions.Version.from_string("1.5")
-    )
-    from_version = versions.Version.from_string("0")
+    settings = configuration.Settings(target_version=Version.from_string("1.5"))
+    from_version = Version.from_string("0")
 
     with pytest.raises(ValueError):
         list(core.build_migration_plan(settings, from_version=from_version))
@@ -175,8 +167,8 @@ def test_build_migration_plan_db(mocker, known_versions):
     mocker.patch(
         "septentrion.db.get_applied_migrations",
         side_effect=lambda settings, version: {
-            versions.Version.from_string("1.1"): ["a"],
-            versions.Version.from_string("1.2"): [],
+            Version.from_string("1.1"): ["a"],
+            Version.from_string("1.2"): [],
         }[version],
     )
     # Then, regarding the migration files that exist on the disk:
@@ -186,14 +178,14 @@ def test_build_migration_plan_db(mocker, known_versions):
     mocker.patch(
         "septentrion.files.get_migrations_files_mapping",
         side_effect=lambda settings, version: {
-            versions.Version.from_string("1.1"): {
+            Version.from_string("1.1"): {
                 "a": pathlib.Path("a"),
                 "b": pathlib.Path("b"),
             },
-            versions.Version.from_string("1.2"): {
+            Version.from_string("1.2"): {
                 "c": pathlib.Path("c"),
             },
-            versions.Version.from_string("1.3"): {"d": pathlib.Path("d")},
+            Version.from_string("1.3"): {"d": pathlib.Path("d")},
         }[version],
     )
     # The contents of each migration is ignored
@@ -207,15 +199,15 @@ def test_build_migration_plan_db(mocker, known_versions):
     )
     # We'll apply migrations up until 1.2 included
     settings = configuration.Settings(
-        target_version=versions.Version.from_string("1.2"),
+        target_version=Version.from_string("1.2"),
     )
     # And we'll start at version 1.1 included
-    from_version = versions.Version.from_string("1.1")
+    from_version = Version.from_string("1.1")
     plan = core.build_migration_plan(settings=settings, from_version=from_version)
 
     expected = [
         {
-            "version": versions.Version.from_string("1.1"),
+            "version": Version.from_string("1.1"),
             "plan": [
                 # On 1.1, migration a is already applied. It's not manual
                 ("a", True, pathlib.Path("a"), False),
@@ -224,7 +216,7 @@ def test_build_migration_plan_db(mocker, known_versions):
             ],
         },
         {
-            "version": versions.Version.from_string("1.2"),
+            "version": Version.from_string("1.2"),
             "plan": [
                 # migration c also needs to be applied. It's manual (the last True)
                 ("c", False, pathlib.Path("c"), True),
@@ -238,13 +230,13 @@ def test_build_migration_plan_db(mocker, known_versions):
 def test_build_migration_plan_with_schema(mocker, known_versions):
     mocker.patch("septentrion.core.db.get_applied_migrations", return_value=[])
     settings = configuration.Settings(target_version="1.2")
-    from_version = versions.Version.from_string("1.1")
+    from_version = Version.from_string("1.1")
 
     plan = list(core.build_migration_plan(settings=settings, from_version=from_version))
 
     expected = [
-        {"plan": [], "version": versions.Version.from_string("1.1")},
-        {"plan": [], "version": versions.Version.from_string("1.2")},
+        {"plan": [], "version": Version.from_string("1.1")},
+        {"plan": [], "version": Version.from_string("1.2")},
     ]
     assert list(plan) == expected
 
@@ -252,13 +244,13 @@ def test_build_migration_plan_with_schema(mocker, known_versions):
 def test_build_migration_plan_with_no_target_version(mocker, known_versions):
     mocker.patch("septentrion.core.db.get_applied_migrations", return_value=[])
     settings = configuration.Settings(target_version=None)
-    from_version = versions.Version.from_string("1.1")
+    from_version = Version.from_string("1.1")
 
     plan = list(core.build_migration_plan(settings=settings, from_version=from_version))
 
     expected = [
-        {"plan": [], "version": versions.Version.from_string("1.1")},
-        {"plan": [], "version": versions.Version.from_string("1.2")},
-        {"plan": [], "version": versions.Version.from_string("1.3")},
+        {"plan": [], "version": Version.from_string("1.1")},
+        {"plan": [], "version": Version.from_string("1.2")},
+        {"plan": [], "version": Version.from_string("1.3")},
     ]
     assert list(plan) == expected

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from septentrion.utils import is_version, until
+from septentrion.utils import is_version, until, since
 
 
 @pytest.mark.parametrize("value,expected", [("1.2", True), ("bananas", False)])
@@ -20,6 +20,6 @@ def test_until_error():
 
 
 def test_since():
-    values = list(until(range(300), 297))
+    values = list(since(range(300), 297))
 
     assert values == [297, 298, 299]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from septentrion.utils import is_version, until, since
+from septentrion.utils import is_version, since, until
 
 
 @pytest.mark.parametrize("value,expected", [("1.2", True), ("bananas", False)])

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,3 +17,9 @@ def test_until():
 def test_until_error():
     with pytest.raises(ValueError):
         list(until(range(5), 10))
+
+
+def test_since():
+    values = list(until(range(300), 297))
+
+    assert values == [297, 298, 299]


### PR DESCRIPTION
Closes #106 

I've validated that the new test:
- Fails if run before the patch
- Passes if fun after the patch

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

Ping @samuelhamard @matacoder 