### PR TITLE
Publish workflow should just run on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - '*'
-  release:
-    types:
-      - published
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes the publish workflow which runs twice, one of which will fail.

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
