### PR TITLE
Fix call to build_migration_plan (unexpected keyword 'schema_version')

### DIFF
--- a/septentrion/lib.py
+++ b/septentrion/lib.py
@@ -33,7 +33,7 @@ def build_migration_plan(**settings_kwargs):
     lib_kwargs = initialize(settings_kwargs)
     schema_version = core.get_best_schema_version(settings=lib_kwargs["settings"])
     return core.build_migration_plan(
-        settings=lib_kwargs["settings"], schema_version=schema_version
+        settings=lib_kwargs["settings"], from_version=schema_version
     )
 
 

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -65,7 +65,7 @@ def test_build_migration_plan(fake_db, mocker):
     assert lib.build_migration_plan() == "is it ?"
 
     build_migration_plan.assert_called_with(
-        settings=mocker.ANY, schema_version=get_best_schema_version.return_value
+        settings=mocker.ANY, from_version=get_best_schema_version.return_value
     )
 
 


### PR DESCRIPTION
Closes #<ticket number>

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
